### PR TITLE
removed playaudio to play beep and used standard system alert sound i…

### DIFF
--- a/odoo_sentinel/__init__.py
+++ b/odoo_sentinel/__init__.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from functools import reduce
 
 from halo import Halo
-from playsound import playsound
+# from playsound import playsound
 
 locale.setlocale(locale.LC_ALL, '')
 encoding = locale.getpreferredencoding()
@@ -391,7 +391,8 @@ class Sentinel(object):
                         if beep:
                             try:
                                 # Play an audio file
-                                playsound(self.audio_file)
+                                # playsound(self.audio_file)
+                                os.system("echo -e '\a'")
                             except:
                                 pass
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         'odoorpc',
         'halo',
-        'playsound',
+        # 'playsound',
     ],
     setup_requires=[
         'setuptools_scm',


### PR DESCRIPTION
…nstead.

(Playaudio use pygobject, and on our sentinel box which is using raspbian stretch which is already EOL, package wasn't installing due to dependency issues)